### PR TITLE
Update ansible version (CVE-2020-14365)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.9.5
+ansible==2.9.13
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4


### PR DESCRIPTION
Github's Dependabot has pointed out that we're requiring a version of ansible vulnerable to CVE-2020-14365. This updates to the patched revision. This will quiet Dependabot at the very least (not sure that we install packages using the dnf module, which is where the vulnerability lies).